### PR TITLE
Add metadata.json for Plasma 6 light

### DIFF
--- a/plasma/look-and-feel/com.github.yeyushengfan258.WinSur-light/metadata.json
+++ b/plasma/look-and-feel/com.github.yeyushengfan258.WinSur-light/metadata.json
@@ -1,0 +1,41 @@
+{
+    "KPlugin": {
+        "Id": "com.github.yeyushengfan258.WinSur-light",
+        "Name": "WinSur-light",
+        "Description": "WinSur-light theme for kde plasma",
+        "Icon": "",
+        "Authors": [
+            {
+                "Name": "yeyushengfan258",
+                "Email": "yeyushengfan258@aliyun.com"
+            }
+        ],
+        "Category": "",
+        "License": "GPL3.0",
+        "Version": "",
+        "Website": "https://github.com/yeyushengfan258/WinSur-light-kde"
+    },
+    "Keywords": [
+        "Desktop",
+        "Workspace",
+        "Appearance",
+        "Look and Feel",
+        "Logout",
+        "Lock",
+        "Suspend",
+        "Shutdown",
+        "Hibernate"
+    ],
+    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPackageDependencies": [
+        "kns://colorschemes.knsrc/api.kde-look.org/1373213",
+        "kns://plasma-themes.knsrc/api.kde-look.org/1373219",
+        "kns://aurorae.knsrc/api.kde-look.org/1373215",
+        "kns://icons.knsrc/api.kde-look.org/1440037",
+        "kns://wallpaper.knsrc/api.kde-look.org/1373212",
+        "kns://sddmtheme.knsrc/api.kde-look.org/1373216",
+        "kns://xcursor.knsrc/api.kde-look.org/1381566"
+    ],
+    "X-Plasma-MainScript": "defaults",
+    "X-KDE-fallbackPackage": "org.kde.breeze.desktop"
+}


### PR DESCRIPTION
The light theme cannot be selected as a global theme on Plasma 6 because it lacks the required metadata.json file. The metadata.desktop file has been converted to json which fixes this issue.

Thank you for this theme, I really like it!